### PR TITLE
docs: add Telegram bot link to README and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A powerful Flask-based Telegram bot powered by Groq and Together AI for chat and image generation.
 
+🤖 **Try the bot now**: [A_iFusion_bot](https://t.me/A_iFusion_bot)
+
 ## Features
 
 - 🤖 Advanced AI Chat using Groq

--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -1,0 +1,33 @@
+# Telegram Bot Access
+
+Our AI Fusion Bot is available on Telegram for immediate use. You can access it through the following methods:
+
+## Quick Access
+
+- **Direct Link**: [A_iFusion_bot](https://t.me/A_iFusion_bot)
+- **Search**: Search for `@A_iFusion_bot` in Telegram
+
+## Getting Started
+
+1. Click the link above or search for the bot in Telegram
+2. Click "Start" or send `/start` to begin
+3. Use `/help` to see all available commands
+
+## Features
+
+- AI-powered chat conversations using Groq
+- Image generation with Together AI
+- Chat history management
+- Customizable settings
+- Export functionality
+
+## Available Commands
+
+See our [Commands](commands.md) documentation for a full list of available commands and their usage.
+
+## Support
+
+If you encounter any issues or need assistance, please:
+1. Check the `/help` command in the bot
+2. Review our [documentation](index.md)
+3. Report issues on our GitHub repository


### PR DESCRIPTION
## Changes
- Add direct Telegram bot link (@A_iFusion_bot) to README.md
- Create new documentation file [docs/telegram-bot.md](cci:7://file:///d:/NovaChat-AI/docs/telegram-bot.md:0:0-0:0)
- Add comprehensive bot usage instructions and features

## Details
- Added clickable Telegram bot link near the top of README for better visibility
- Created dedicated documentation covering:
  - Quick access methods
  - Getting started guide
  - Available features
  - Command references
  - Support information

## Testing
- Verified all links are working and redirect correctly
- Confirmed documentation formatting renders properly
- Ensured integration with existing docs structure

## Related Issues
None